### PR TITLE
format json output to valid parsable object

### DIFF
--- a/src/srv/server.cpp
+++ b/src/srv/server.cpp
@@ -32,7 +32,7 @@ auto respond(int count, auto req) {
       restinio::http_field::content_type, fmt::format("{}; charset=utf-8", content_type));
 
   if (cli.json) {
-    response.set_body(fmt::format("{{count:{}}}\n", count));
+    response.set_body(fmt::format("{{\"count\":{}}}", count));
   } else {
     response.set_body(fmt::format("{}\n", count));
   }


### PR DESCRIPTION
This resolves #9 , wrapping `count` in quotes and removes the newline character. The output should be `{"count": 123}`.