### PR TITLE
fixed a couple of bugs in the shell scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,30 +15,30 @@ NOPCH="-DNOPCH=OFF"      # override cmake cache
 TESTS=
 GENERATEONLY=
 VERBOSE=
-TARGETS=
+TARGETS=()
 INSTALL=
 INSTALL_PREFIX=
 
 USAGE=$(cat <<-END
 
-	Convenience script around `cmake` invocation
+    Convenience script around $CMAKE invocation
 
-	Usage: $(basename $0) options
+    Usage: $(basename "$0") options
 
-	Options:
+    Options:
 
-	 -c | --compiler 	  specify the compile [ gcc | clang ] default is ${COMPILER}
-	 -b | --buildtype 	  select buildtype [ debug | release | relwithdebinfo ]. default is ${BUILDTYPE}
-	 -t | --targets 	  spefify targets  tgt1,tgt2,tgt3 
-	 -g | --generate-only     only generate, don't build
-	 --clean-first            cleans the selected targets before building (recompiles everything for those targets)
-	 -p | --purge 		  completely wipe the selected build directory (deletes cmake config, implies --clean-first)
-	 --install                install after building
-	 --install-prefix         the prefix for install, defaults to /usr/local
-	 --run-tests              run all tests immediately after build  (is "sticky" in cmake cache)
-	 --skip-tests             skip running tests  (is "sticky" in cmake cache)
-	 -v | --verbose 	  get verbose compiler command lines
-	 -h | --help              show this info
+     -c | --compiler          specify the compiler [ gcc | clang ] default is ${COMPILER}
+     -b | --buildtype         select buildtype [ debug | release | relwithdebinfo ]. default is ${BUILDTYPE}
+     -t | --targets           specify targets tgt1,tgt2,tgt3
+     -g | --generate-only     only generate, don't build
+     --clean-first            cleans the selected targets before building (recompiles everything for those targets)
+     -p | --purge             completely wipe the selected build directory (deletes cmake config, implies --clean-first)
+     --install                install after building
+     --install-prefix         the prefix for install, defaults to /usr/local
+     --run-tests              run all tests immediately after build (is "sticky" in cmake cache)
+     --skip-tests             skip running tests (is "sticky" in cmake cache)
+     -v | --verbose           get verbose compiler command lines
+     -h | --help              show this info
 
 END
 )
@@ -48,73 +48,79 @@ if command -v /usr/local/bin/getopt > /dev/null 2>&1; then
     GETOPT='/usr/local/bin/getopt'
 fi
 
-options=$($GETOPT --options hvc:b:t:pg --long help,verbose,compiler:,buildtype:,targets:,purge,generate-only,run-tests,skip-tests,install,install-prefix:,clean-first,nopch -- "$@")
+options=$("$GETOPT" --options hvc:b:t:pg --long help,verbose,compiler:,buildtype:,targets:,purge,generate-only,run-tests,skip-tests,install,install-prefix:,clean-first,nopch -- "$@")
 
 eval set -- "$options"
 while true; do
     case "$1" in
-	--help|-h)
-	    echo "$USAGE";
-	    exit 0;;
-	-v|--verbose)
-	    VERBOSE='--verbose'
-	    ;;
-	-c|--compiler)
-	    shift
-	    COMPILER=$1
-	    [[ ! $COMPILER =~ ^(gcc(-[0-9]+)?|clang(-[0-9]+)?)$ ]] && {
-		echo "[--compiler | -c] must be gcc[-xx] or clang[-xx]"
-		exit 1
-            }
-	    ;;
-	-b|--buildtype)
-	    shift
-	    BUILDTYPE=${1,,}
-	    [[ ! $BUILDTYPE =~ debug|release|relwithdebinfo ]] && {
-		echo "[--buildtype | -b] must be debug|release|relwithdebinfo"
-		exit 1
-            }
-	    ;;
-	-t|--targets)
-	    shift;
-	    TARGETS="--target ${1//,/ }"; 
-	    ;;
-	-p|--purge)
-            PURGE=1
-	    ;;
-	-g|--generateonly)
-	    GENERATEONLY=1
-	    ;;
-	--clean-first)
-	    CLEAN_FIRST="--clean-first"
-	    ;;
-	--install)
-	    INSTALL=1
-	    ;;
-	--install-prefix)
-	    shift
-	    INSTALL_PREFIX="-DCMAKE_INSTALL_PREFIX=$1"
-	    ;;
-	--nopch)
-	    NOPCH="-DNOPCH=ON"
-	    ;;
-	--run-tests)
-	    TESTS="-DHIBP_TEST=ON"
-	    ;;
-	--skip-tests)
-	    TESTS="-DHIBP_TEST=OFF"
-	    ;;
-	--)
-	    shift
-	    break
-	    ;;
+    --help|-h)
+        echo "$USAGE"
+        exit 0
+        ;;
+    -v|--verbose)
+        VERBOSE='--verbose'
+        ;;
+    -c|--compiler)
+        shift
+        COMPILER=$1
+        [[ ! "$COMPILER" =~ ^(gcc(-[0-9]+)?|clang(-[0-9]+)?)$ ]] && {
+            echo "[--compiler | -c] must be gcc[-xx] or clang[-xx]" >&2
+            exit 1
+        }
+        ;;
+    -b|--buildtype)
+        shift
+        BUILDTYPE=${1,,}
+        [[ ! "$BUILDTYPE" =~ debug|release|relwithdebinfo ]] && {
+            echo "[--buildtype | -b] must be debug|release|relwithdebinfo" >&2
+            exit 1
+        }
+        ;;
+    -t|--targets)
+        shift
+        [ -z "$1" ] && echo "--targets parameter must not be empty" >&2 && exit 1
+        set -- ${1//,/ }
+        TARGETS=(
+            "--target"
+            "$@"
+        )
+        ;;
+    -p|--purge)
+        PURGE=1
+        ;;
+    -g|--generateonly)
+        GENERATEONLY=1
+        ;;
+    --clean-first)
+        CLEAN_FIRST="--clean-first"
+        ;;
+    --install)
+        INSTALL=1
+        ;;
+    --install-prefix)
+        shift
+        INSTALL_PREFIX="-DCMAKE_INSTALL_PREFIX=$1"
+        ;;
+    --nopch)
+        NOPCH="-DNOPCH=ON"
+        ;;
+    --run-tests)
+        TESTS="-DHIBP_TEST=ON"
+        ;;
+    --skip-tests)
+        TESTS="-DHIBP_TEST=OFF"
+        ;;
+    --)
+        shift
+        break
+        ;;
     esac
     shift
 done
 
 [[ $# -gt 0 ]] && echo "unexpected argument '$1'" && exit 1
 
-cd "$(realpath $(dirname $0))"
+cd "$(realpath "$(dirname "$0")")"
 
 BUILD_DIR=$BUILDROOT/$COMPILER/$BUILDTYPE
 
@@ -126,36 +132,64 @@ else
     CXX_COMPILER=${COMPILER/gcc/g++}
 fi
 
-if command -v ccache > /dev/null 2>&1; then
-    CACHE="-DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache"
-else
-    CACHE=""
-fi
+BUILD_OPTIONS=(
+    "-DCMAKE_C_COMPILER=$C_COMPILER"
+    "-DCMAKE_CXX_COMPILER=$CXX_COMPILER"
+    "-DCMAKE_BUILD_TYPE=$BUILDTYPE"
+)
 
-BUILD_OPTIONS="-DCMAKE_C_COMPILER=$C_COMPILER -DCMAKE_CXX_COMPILER=$CXX_COMPILER -DCMAKE_BUILD_TYPE=$BUILDTYPE $TESTS $INSTALL_PREFIX"
+[ -n "$TESTS" ] && BUILD_OPTIONS+=("$TESTS")
+[ -n "$INSTALL_PREFIX" ] && BUILD_OPTIONS+=("$INSTALL_PREFIX")
+
+if command -v ccache > /dev/null 2>&1; then
+    BUILD_OPTIONS+=(
+        "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+        "-DCMAKE_C_COMPILER_LAUNCHER=ccache"
+    )
+fi
 
 if command -v mold > /dev/null 2>&1; then
-    BUILD_OPTIONS="$BUILD_OPTIONS -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=mold -DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=mold"
+    BUILD_OPTIONS+=(
+        "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=mold"
+        "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=mold"
+    )
 fi
 
-[[ -n $PURGE && -d $BUILD_DIR ]] && rm -rf $BUILD_DIR
+[[ -n "$PURGE" && -d "$BUILD_DIR" ]] && rm -rf "$BUILD_DIR"
 
-GEN_CMD="$CMAKE -GNinja -S . -B $BUILD_DIR $CACHE -DCMAKE_COLOR_DIAGNOSTICS=ON -DBINFUSE_TEST=OFF $BUILD_OPTIONS $NOPCH"
-[[ -n $VERBOSE ]] && echo "$GEN_CMD"
-$GEN_CMD
-GEN_RET=$?
+GEN_CMD=(
+    "$CMAKE"
+    "-GNinja"
+    "-S" "."
+    "-B" "$BUILD_DIR"
+    "-DCMAKE_COLOR_DIAGNOSTICS=ON"
+    "-DBINFUSE_TEST=OFF"
+    "${BUILD_OPTIONS[@]}"
+    "$NOPCH"
+)
+[[ -n "$VERBOSE" ]] && echo "${GEN_CMD[@]}"
+"${GEN_CMD[@]}" && GEN_RET=$? || GEN_RET=$?
 
-[[ $GEN_RET ]] && rm -f ./compile_commands.json && ln -s $BUILD_DIR/compile_commands.json .
+[[ $GEN_RET -eq 0 ]] && rm -f ./compile_commands.json && ln -s "$BUILD_DIR/compile_commands.json" .
 
-[[ -n $GENERATEONLY ]] && exit $GEN_RET
+[[ -n "$GENERATEONLY" ]] && exit $GEN_RET
 
-BUILD_CMD="$CMAKE --build $BUILD_DIR $CLEAN_FIRST $TARGETS -- $VERBOSE"
-[[ -n $VERBOSE ]] && echo "$BUILD_CMD"
-$BUILD_CMD
-BUILD_RET=$?
+BUILD_CMD=(
+    "$CMAKE"
+    "--build" "$BUILD_DIR"
+)
+[ -n "${TARGETS[@]}" ] && BUILD_CMD+=("${TARGETS[@]}")
+[ -n "$CLEAN_FIRST" ] && BUILD_CMD+=("$CLEAN_FIRST")
+BUILD_CMD+=(
+    "--"
+    "$VERBOSE"
+)
 
-if [[ BUILD_RET -eq 0 && -n $INSTALL ]]; then
-    cmake --install $BUILD_DIR
+[[ -n $VERBOSE ]] && echo "${BUILD_CMD[@]}"
+"${BUILD_CMD[@]}" && BUILD_RET=$? || BUILD_RET=$?
+
+if [[ $BUILD_RET -eq 0 && -n "$INSTALL" ]]; then
+    cmake --install "$BUILD_DIR"
 else
     exit $BUILD_RET
 fi

--- a/release.sh
+++ b/release.sh
@@ -1,41 +1,44 @@
 #!/usr/bin/env bash
 
+set -o errexit
+set -o nounset
+
 OLD_VERSION="$1"
 NEW_VERSION="$2"
 
-PROJECT_DIR="$(dirname $(realpath $0))"
+PROJECT_DIR="$(dirname "$(realpath "$0")")"
 
 USAGE=$(cat <<-END
     	Usage: $0 OLD_VERSION NEW_VERSION
 END
      )
 
-if [[ -z $OLD_VERSION || -z $NEW_VERSION ]]
+if [[ -z "$OLD_VERSION" || -z "$NEW_VERSION" ]]
 then
-    echo $USAGE
+    echo "$USAGE"
     exit 1
 fi
 
-NEW_PACKAGE_DIR="$HOME/hibp_$NEW_VERSION-1_amd64"
+NEW_PACKAGE_DIR="$HOME/hibp_${NEW_VERSION}-1_amd64"
 
 sed -i "s/${OLD_VERSION//./\\.}/${NEW_VERSION//./\\.}/g" DEBIAN/control README.md
 
-rm -rf $NEW_PACKAGE_DIR
-mkdir -p $NEW_PACKAGE_DIR/DEBIAN/
-egrep -v '^Depends:' $PROJECT_DIR/DEBIAN/control > $NEW_PACKAGE_DIR/DEBIAN/control
+rm -rf "$NEW_PACKAGE_DIR"
+mkdir -p "$NEW_PACKAGE_DIR/DEBIAN"
+egrep -v '^Depends:' "$PROJECT_DIR/DEBIAN/control" > "$NEW_PACKAGE_DIR/DEBIAN/control"
 
 git pull &&
-    ./build.sh -c gcc -b release --purge --nopch --run-tests --install --install-prefix=$NEW_PACKAGE_DIR/usr/local &&
-    cd $NEW_PACKAGE_DIR &&
+    ./build.sh -c gcc -b release --purge --nopch --run-tests --install "--install-prefix=$NEW_PACKAGE_DIR/usr/local" &&
+    cd "$NEW_PACKAGE_DIR" &&
     mkdir debian &&
     touch debian/control && # needs to present temporarily
     DEPS="$(dpkg-shlibdeps -O usr/local/bin/hibp-* 2>/dev/null)" &&
     echo "Depends: ${DEPS/shlibs:Depends=/}" >> DEBIAN/control &&
-    cp $NEW_PACKAGE_DIR/DEBIAN/control $PROJECT_DIR/DEBIAN/control
-    rm -rf $NEW_PACKAGE_DIR/debian &&
-    cd $NEW_PACKAGE_DIR/.. &&
-    dpkg-deb --build --root-owner-group $NEW_PACKAGE_DIR &&
-    cd $PROJECT_DIR
+    cp "$NEW_PACKAGE_DIR/DEBIAN/control" "$PROJECT_DIR/DEBIAN/control"
+    rm -rf "$NEW_PACKAGE_DIR/debian" &&
+    cd "$NEW_PACKAGE_DIR/.." &&
+    dpkg-deb --build --root-owner-group "$NEW_PACKAGE_DIR" &&
+    cd "$PROJECT_DIR"
 
 echo "package built, if all works nicely do this:"
 echo

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -3,4 +3,5 @@
 # in adition to your IDE clang-format,it is worth running this
 # periodically to ensure all formatting errors have been caught.
 
-find app/ src/ test/ include/ -type f -name '*.cpp' -or -name '*.hpp' | xargs clang-format --verbose -i
+find app/ src/ test/ include/ -type f \( -name '*.cpp' -o -name '*.hpp' \) -print0 \
+    | xargs -r -0 clang-format --verbose -i

--- a/scripts/clang-tidy.sh
+++ b/scripts/clang-tidy.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
-# in adition to your IDE clang-tidy,it is worth running this
+# in addition to your IDE clang-tidy, it is worth running this
 # periodically to ensure all warnings have been caught. This is
 # particularly true with respect to #include warnings which have been
 # masked by precompiled headers
 
-# ensure we have genrated a compile_commands.json without precompiled headers
+# ensure we have generated a compile_commands.json without precompiled headers
 ./build.sh -c clang -b debug --run-tests --nopch -g >/dev/null
 
 # Use clang-tidy -p to force read of compile_commands.json in the
 # current directory. This is quite a slow process and may take
 # several minutes, hence the use of gnu parallel.
-time find app/ src/ include/ test/ -type f -name '*.cpp' -or -name '*.hpp' | \
-    nice parallel -q clang-tidy --quiet -p --config-file=.clang-tidy \
+time find app/ src/ include/ test/ -type f \( -name '*.cpp' -o -name '*.hpp' \) -print0 | \
+    nice parallel -0 -q clang-tidy --quiet -p --config-file=.clang-tidy \
 	 -header-filter='.*/hibp/include/.*' --use-color

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-
 ./build.sh -c gcc -b debug -t hibp_search
 ./build/gcc/debug/hibp-download hibp_sample.sha1.bin --force --no-progress 2>/dev/null 1>/dev/null &
 pid=$!
@@ -13,5 +12,5 @@ kill $pid
 exit
 
 # attaching to running process in windows (mingw)
-gdb /home/oliver/hibp/build/gcc/debug/hibp-download
-gdb /home/oliver/hibp/build/gcc/debug/hibp-download $(ps -W | egrep "hibp-download" | awk "{print $4}")
+gdb "$HOME/hibp/build/gcc/debug/hibp-download"
+gdb "$HOME/hibp/build/gcc/debug/hibp-download" $(pgrep "hibp-download")

--- a/scripts/pragma_check.sh
+++ b/scripts/pragma_check.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-for header in $(find src include -name '*.hpp' -or -name '*.h')
+find src include \( -name '*.hpp' -o -name '*.h' \) -print0 | while read -d $'\0' header
 do
     if ! egrep '^#pragma once' $header >/dev/null
     then
-	echo "missing #pragma once: $header"
+        echo "missing #pragma once: $header"
     fi
 done

--- a/scripts/profile_compiler.sh
+++ b/scripts/profile_compiler.sh
@@ -13,15 +13,15 @@ fi
 
 rm -rf build/clang/debug
 
-for SRC_FILE in $(ls app/*.cpp); do
+for SRC_FILE in app/*.cpp; do
     TARGET=$(basename -s .cpp "$SRC_FILE")
     echo  1>&2
     echo "profiling target $TARGET" 1>&2
     echo "===================================="  1>&2
     
-    time ./build.sh -c clang -b debug -t $TARGET | egrep -v '^--'
+    time ./build.sh -c clang -b debug -t "$TARGET" | egrep -v '^--'
     echo '//' >> "$SRC_FILE"  # make small modification
-    time ./build.sh -c clang -b debug -t $TARGET | egrep -v '^--'
+    time ./build.sh -c clang -b debug -t "$TARGET" | egrep -v '^--'
     git checkout "$SRC_FILE" > /dev/null 2>&1 # revert change
     echo "open chrome at chrome://tracing  and load  build/clang/debug/CMakeFiles/$TARGET.dir/app/$SRC_FILE.json"
 done

--- a/scripts/profile_compiler.sh
+++ b/scripts/profile_compiler.sh
@@ -7,7 +7,7 @@ then
 fi
 if git status app | egrep modified
 then
-    echo "ensure you have comttted, stashed or reverted any changes in app/" 1>&2 
+    echo "ensure you have committed, stashed or reverted any changes in app/" 1>&2 
     exit 1
 fi
 


### PR DESCRIPTION
Some of the fixed issues:
* variables were used as commandline arguments without being in quotes and with the possibility of containing whitespaces (where the contents of the variable would be split into multiple commandline arguments upon expansion)
* indentation was not coherent (both tabs and spaces were used)
* filepathes can contain whitespace characters (including newlines) and some of the scripts didn't account for this
* build.sh failed with unbound variable if it's last commandline argument was a "--"
* a couple of typos