### PR TITLE
fix: update CI condition trigger

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,6 +1,10 @@
 name: FreeBSD-14.1 clang-18.1
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   freebsd-build:

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -1,6 +1,10 @@
 name: Windows MINGW32/64 gcc/clang
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   windows-mingw:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,6 +1,10 @@
 name: Ubuntu 24.04 (gcc-13, clang-18)
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   ubuntu-build:


### PR DESCRIPTION
Currently, trigger is both `on push`  and `on pull_request`.

When doing this in **own repo**, this duplicates GitHub Actions executed - runs both `on` triggers.

By defining the condition to run `on push` with `branch` name, this gets solved.